### PR TITLE
Fix shebang for obscure platforms

### DIFF
--- a/src/zazu.py
+++ b/src/zazu.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 import logging
 import configparser
 import twitter


### PR DESCRIPTION
For users using PyEnv, Conda, NixOS et cetera, the entrypoint for Python may not be at `/usr/bin/python3`. Using `/usr/bin/env` provides a more robust way to find the Python binary.