### PR TITLE
zazu: catch ValueError instead of generic Exception, fixes #6...

### DIFF
--- a/src/zazu.py
+++ b/src/zazu.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import random
+import time
 import os
 import re
 import sys
@@ -77,7 +79,11 @@ def post_tweet(config, tweettext):
     except ValueError as error:
         logging.error("get_api %s: %s", type(error), error)
         sys.exit(1) # do not update the source file
-
+        randomtime = 60 * random.randrange(0, int(
+            config.get('general', 'random_time')))
+        logging.info(("sleeping for %d seconds (%.2f minutes)"
+                      " before posting tweet"), randomtime, randomtime / 60)
+        time.sleep(randomtime)
     try:
         post_update = api.PostUpdate(tweettext, trim_user=True,
                                      verify_status_length=True)
@@ -87,6 +93,9 @@ def post_tweet(config, tweettext):
     except ValueError as error:
         logging.error("post_update %s: %s", type(error), error)
         sys.exit(1) # do not update the source file
+        logging.info("tweeted %s at %s", post_update.text,
+                     post_update.created_at)
+        logging.debug("full post_update info: %s", str(post_update))
     return post_update
 
 

--- a/src/zazu.py
+++ b/src/zazu.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-import random
-import time
 import os
 import re
 import sys
@@ -74,25 +72,21 @@ def post_tweet(config, tweettext):
     try:
         api = get_api(config)
     except twitter.error.TwitterError as error:
-        logging.error("TwitterError: %s", error)
+        logging.error("TwitterError get_api: %s", error)
         sys.exit(1) # do not update the source file
-    except Exception as error:
-        logging.error("%s: %s", type(error), error)
+    except ValueError as error:
+        logging.error("get_api %s: %s", type(error), error)
         sys.exit(1) # do not update the source file
-        randomtime = 60 * random.randrange(0, int(
-            config.get('general', 'random_time')))
-        logging.info(("sleeping for %d seconds (%.2f minutes)"
-                      " before posting tweet"), randomtime, randomtime / 60)
-        time.sleep(randomtime)
+
     try:
         post_update = api.PostUpdate(tweettext, trim_user=True,
                                      verify_status_length=True)
-    except Exception as error:
-        logging.error("%s: %s", type(error), error)
+    except twitter.error.TwitterError as error:
+        logging.error("TwitterError post_update: %s", error)
         sys.exit(1) # do not update the source file
-        logging.info("tweeted %s at %s", post_update.text,
-                     post_update.created_at)
-        logging.debug("full post_update info: %s", str(post_update))
+    except ValueError as error:
+        logging.error("post_update %s: %s", type(error), error)
+        sys.exit(1) # do not update the source file
     return post_update
 
 


### PR DESCRIPTION
remove unreachable code and unused imports, clarify logging messages (where do they come from).

The only exception raised in `Api` is `TwitterError`. The only exception raised in `zazu` is `ValueError`. There might be more, but I think it's better to add specific exceptions when you encounter them. You have a log of all exceptions (if any), so it would be handy to provide a list of (most common) exceptions.